### PR TITLE
deprecate use of Pod::LaTeX from core

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -32,7 +32,7 @@ my $build = Module::Build->new
    build_requires => {
                       'Test::More' => 0,
                      },
-   installdirs => ( $] > 5.006 ? "core" : "site" ),
+   installdirs => ( $] > 5.006 and $] <= 5.012 ? "core" : "site" ),
   );
 
 $build->create_build_script;

--- a/Build.PL
+++ b/Build.PL
@@ -25,6 +25,7 @@ my $build = Module::Build->new
                 'Pod::Parser' => 0,
                 'Pod::ParseUtils' => 0.30,
                 'Pod::Select' => 0,
+                'if' => 0,
                },
    PL_files => { 'pod2latex.PL' => 'pod2latex' },
    script_files => [ 'pod2latex' ],

--- a/lib/Pod/LaTeX.pm
+++ b/lib/Pod/LaTeX.pm
@@ -28,6 +28,8 @@ use strict;
 require Pod::ParseUtils;
 use base qw/ Pod::Select /;
 
+use if $] > 5.017, 'deprecate';
+
 # use Data::Dumper; # for debugging
 use Carp;
 


### PR DESCRIPTION
These commits should cause Pod::LaTeX to install to "site" in v5.12 and later, and to issue a deprecation warning when run from the core install starting with v5.17.

I have not tested the deprecation warning yet, and am making this pull request tentatively.  Either I will test it and update the PR or someone else will test it.  I just need to switch tasks now.
